### PR TITLE
Added documentation for Abyssal Tweaker

### DIFF
--- a/docs/groovy-script/mods/abyssaltweaker/crystallization.md
+++ b/docs/groovy-script/mods/abyssaltweaker/crystallization.md
@@ -1,0 +1,109 @@
+---
+title: "Crystallization"
+titleTemplate: "Abyssal Tweaker | CleanroomMC"
+description: "Converts an input ItemStack into one or two ItemStacks, consuming Crystallizer fuel."
+source_code_link: "https://github.com/TeamDimensional/AbyssalTweaker/blob/master/src/main/java/com/teamdimensional/abyssaltweaker/compat/groovyscript/RegistryCrystallization.java"
+---
+
+# Crystallization (Abyssal Tweaker)
+
+## Description
+
+Converts an input ItemStack into one or two ItemStacks, consuming Crystallizer fuel.
+
+## Identifier
+
+Refer to this via any of the following:
+
+```groovy:no-line-numbers {1}
+mods.abyssaltweaker.crystallization/* Used as page default */ // [!code focus]
+mods.abyssaltweaker.Crystallization
+```
+
+
+## Adding Recipes
+
+### Recipe Builder
+
+Just like other recipe types, the Crystallization also uses a recipe builder.
+
+Don't know what a builder is? Check [the builder info page](../../getting_started/builder.md) out.
+
+:::::::::: details mods.abyssaltweaker.crystallization.recipeBuilder() {open id="abstract"}
+- `IngredientList<IIngredient>`. Sets the item inputs of the recipe. Requires exactly 1.
+
+    ```groovy:no-line-numbers
+    input(IIngredient)
+    input(IIngredient...)
+    input(Collection<IIngredient>)
+    ```
+
+- `ItemStackList`. Sets the item outputs of the recipe. Requires greater than or equal to 1 and less than or equal to 2.
+
+    ```groovy:no-line-numbers
+    output(ItemStack)
+    output(ItemStack...)
+    output(Collection<ItemStack>)
+    ```
+
+- `float`. Sets the XP amount output that is given out when the recipe is executed. Requires greater than or equal to 0. (Default `0.0f`).
+
+    ```groovy:no-line-numbers
+    xp(float)
+    ```
+
+- First validates the builder, returning `null` and outputting errors to the log file if the validation failed, then registers the builder and returns the registered object. (returns `null` or `com.shinoow.abyssalcraft.api.recipe.Crystallization`).
+
+    ```groovy:no-line-numbers
+    register()
+    ```
+
+::::::::: details Example {open id="example"}
+```groovy:no-line-numbers
+mods.abyssaltweaker.crystallization.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .output(item('minecraft:diamond'))
+    .xp(0.5)
+    .register()
+```
+
+:::::::::
+
+::::::::::
+
+## Removing Recipes
+
+- Removes all recipes that match the given input:
+
+    ```groovy:no-line-numbers
+    mods.abyssaltweaker.crystallization.removeByInput(IIngredient)
+    ```
+
+- Removes all recipes that match the given output:
+
+    ```groovy:no-line-numbers
+    mods.abyssaltweaker.crystallization.removeByOutput(IIngredient)
+    ```
+
+- Removes all registered recipes:
+
+    ```groovy:no-line-numbers
+    mods.abyssaltweaker.crystallization.removeAll()
+    ```
+
+:::::::::: details Example {open id="example"}
+```groovy:no-line-numbers
+mods.abyssaltweaker.crystallization.removeByInput(item('minecraft:blaze_powder'))
+mods.abyssaltweaker.crystallization.removeByOutput(item('abyssalcraft:copper_crystal'))
+mods.abyssaltweaker.crystallization.removeAll()
+```
+
+::::::::::
+
+## Getting the value of recipes
+
+- Iterates through every entry in the registry, with the ability to call remove on any element to remove it:
+
+    ```groovy:no-line-numbers
+    mods.abyssaltweaker.crystallization.streamRecipes()
+    ```

--- a/docs/groovy-script/mods/abyssaltweaker/fuel.md
+++ b/docs/groovy-script/mods/abyssaltweaker/fuel.md
@@ -1,0 +1,66 @@
+---
+title: "Fuel"
+titleTemplate: "Abyssal Tweaker | CleanroomMC"
+description: "Allows configuring the items that can be used as Transmutator and/or Crystallizer fuels."
+source_code_link: "https://github.com/CleanroomMC/GroovyScript/blob/master/src/main/java/com/teamdimensional/abyssaltweaker/compat/groovyscript/Fuel.java"
+---
+
+# Fuel (Abyssal Tweaker)
+
+## Description
+
+Allows configuring the items that can be used as Transmutator and/or Crystallizer fuels.
+
+## Identifier
+
+Refer to this via any of the following:
+
+```groovy:no-line-numbers {1}
+mods.abyssaltweaker.fuel/* Used as page default */ // [!code focus]
+mods.abyssaltweaker.Fuel
+```
+
+
+## Adding Entries
+
+- Adds a Crystallizer fuel:
+
+    ```groovy:no-line-numbers
+    mods.abyssaltweaker.fuel.addCrystallizer(IIngredient, int)
+    ```
+
+- Adds a Transmutator fuel:
+
+    ```groovy:no-line-numbers
+    mods.abyssaltweaker.fuel.addTransmutator(IIngredient, int)
+    ```
+
+:::::::::: details Example {open id="example"}
+```groovy:no-line-numbers
+mods.abyssaltweaker.fuel.addCrystallizer(item('minecraft:stone'), 50)
+mods.abyssaltweaker.fuel.addTransmutator(item('minecraft:cobblestone'), 50)
+```
+
+::::::::::
+
+## Removing Entries
+
+- Removes a Crystallizer fuel:
+
+    ```groovy:no-line-numbers
+    mods.abyssaltweaker.fuel.removeCrystallizer(IIngredient)
+    ```
+
+- Removes a Transmutator fuel:
+
+    ```groovy:no-line-numbers
+    mods.abyssaltweaker.fuel.removeTransmutator(IIngredient)
+    ```
+
+:::::::::: details Example {open id="example"}
+```groovy:no-line-numbers
+mods.abyssaltweaker.fuel.removeCrystallizer(item('abyssalcraft:dreadshard'))
+mods.abyssaltweaker.fuel.removeTransmutator(item('minecraft:blaze_rod'))
+```
+
+::::::::::

--- a/docs/groovy-script/mods/abyssaltweaker/index.md
+++ b/docs/groovy-script/mods/abyssaltweaker/index.md
@@ -1,0 +1,21 @@
+---
+aside: false
+---
+
+
+# Abyssal Tweaker
+
+## Categories
+
+Has 5 subcategories.
+
+* [Crystallization](./crystallization.md)
+
+* [Fuel](./fuel.md)
+
+* [Materialization](./materialization.md)
+
+* [Necronomicon Ritual](./ritual.md)
+
+* [Transmutation](./transmutation.md)
+

--- a/docs/groovy-script/mods/abyssaltweaker/materialization.md
+++ b/docs/groovy-script/mods/abyssaltweaker/materialization.md
@@ -1,0 +1,106 @@
+---
+title: "Materialization"
+titleTemplate: "Abyssal Tweaker | CleanroomMC"
+description: "Turns Crystals from a Crystal Bag into an output item."
+source_code_link: "https://github.com/TeamDimensional/AbyssalTweaker/blob/master/src/main/java/com/teamdimensional/abyssaltweaker/compat/groovyscript/RegistryMaterialization.java"
+---
+
+# Materialization (Abyssal Tweaker)
+
+## Description
+
+Turns Crystals from a Crystal Bag into an output item.
+
+:::::::::: details Warning {open id="warning"}
+The Materializer compatibility will only take the first item that satisfies each ingredient into account. This is fine if ItemIngredients are used, but will not work with OrIngredients and the like.
+::::::::::
+
+## Identifier
+
+Refer to this via any of the following:
+
+```groovy:no-line-numbers {1}
+mods.abyssaltweaker.materialization/* Used as page default */ // [!code focus]
+mods.abyssaltweaker.Materialization
+```
+
+
+## Adding Recipes
+
+### Recipe Builder
+
+Just like other recipe types, the Materialization also uses a recipe builder.
+
+Don't know what a builder is? Check [the builder info page](../../getting_started/builder.md) out.
+
+:::::::::: details mods.abyssaltweaker.materialization.recipeBuilder() {open id="abstract"}
+- `IngredientList<IIngredient>`. Sets the item inputs of the recipe. Requires greater than or equal to 1 and less than or equal to 5.
+
+    ```groovy:no-line-numbers
+    input(IIngredient)
+    input(IIngredient...)
+    input(Collection<IIngredient>)
+    ```
+
+- `ItemStackList`. Sets the item outputs of the recipe. Requires exactly 1.
+
+    ```groovy:no-line-numbers
+    output(ItemStack)
+    output(ItemStack...)
+    output(Collection<ItemStack>)
+    ```
+
+- First validates the builder, returning `null` and outputting errors to the log file if the validation failed, then registers the builder and returns the registered object. (returns `null` or `com.shinoow.abyssalcraft.api.recipe.Materialization`).
+
+    ```groovy:no-line-numbers
+    register()
+    ```
+
+::::::::: details Example {open id="example"}
+```groovy:no-line-numbers
+mods.abyssaltweaker.materialization.recipeBuilder()
+    .input(item('abyssalcraft:coralium_crystal'))
+    .output(item('minecraft:diamond'))
+    .register()
+```
+
+:::::::::
+
+::::::::::
+
+## Removing Recipes
+
+- Removes all recipes that match the given input:
+
+    ```groovy:no-line-numbers
+    mods.abyssaltweaker.materialization.removeByInput(IIngredient)
+    ```
+
+- Removes all recipes that match the given output:
+
+    ```groovy:no-line-numbers
+    mods.abyssaltweaker.materialization.removeByOutput(IIngredient)
+    ```
+
+- Removes all registered recipes:
+
+    ```groovy:no-line-numbers
+    mods.abyssaltweaker.materialization.removeAll()
+    ```
+
+:::::::::: details Example {open id="example"}
+```groovy:no-line-numbers
+mods.abyssaltweaker.materialization.removeByInput(item('abyssalcraft:phosphorus_crystal'))
+mods.abyssaltweaker.materialization.removeByOutput(item('minecraft:bone'))
+mods.abyssaltweaker.materialization.removeAll()
+```
+
+::::::::::
+
+## Getting the value of recipes
+
+- Iterates through every entry in the registry, with the ability to call remove on any element to remove it:
+
+    ```groovy:no-line-numbers
+    mods.abyssaltweaker.materialization.streamRecipes()
+    ```

--- a/docs/groovy-script/mods/abyssaltweaker/ritual.md
+++ b/docs/groovy-script/mods/abyssaltweaker/ritual.md
@@ -1,0 +1,158 @@
+---
+title: "Necronomicon Ritual"
+titleTemplate: "Abyssal Tweaker | CleanroomMC"
+description: "Allows setting up rituals that can be executed with various tiers of Necronomicon."
+source_code_link: "https://github.com/TeamDimensional/AbyssalTweaker/blob/master/src/main/java/com/teamdimensional/abyssaltweaker/compat/groovyscript/Ritual.java"
+---
+
+# Necronomicon Ritual (Abyssal Tweaker)
+
+## Description
+
+Allows setting up rituals that can be executed with various tiers of Necronomicon.
+
+:::::::::: details Warning {open id="warning"}
+For technical reasons the Ritual compatibility will not validate whether the ritual is executed in a valid dimension. By default only Overworld and Abyssalcraft's dimensions are valid, and other dimensions have to be added through the config file.
+::::::::::
+
+## Identifier
+
+Refer to this via any of the following:
+
+```groovy:no-line-numbers {1}
+mods.abyssaltweaker.ritual/* Used as page default */ // [!code focus]
+mods.abyssaltweaker.Ritual
+```
+
+
+## Adding Recipes
+
+### Recipe Builder
+
+Just like other recipe types, the Necronomicon Ritual also uses a recipe builder.
+
+Don't know what a builder is? Check [the builder info page](../../getting_started/builder.md) out.
+
+:::::::::: details mods.abyssaltweaker.ritual.recipeBuilder() {open id="abstract"}
+- `IngredientList<IIngredient>`. Sets the item inputs of the recipe. Requires greater than or equal to 1 and less than or equal to 9.
+
+    ```groovy:no-line-numbers
+    input(IIngredient)
+    input(IIngredient...)
+    input(Collection<IIngredient>)
+    ```
+
+- `ItemStackList`. Sets the item outputs of the recipe. Requires exactly 1.
+
+    ```groovy:no-line-numbers
+    output(ItemStack)
+    output(ItemStack...)
+    output(Collection<ItemStack>)
+    ```
+
+- `int`. Sets the amount of Potential Energy the ritual consumes. Requires greater than or equal to 1. (Default `0`).
+
+    ```groovy:no-line-numbers
+    pe(int)
+    energy(int)
+    ```
+
+- `String`. Sets the ritual name, which has to be unique among all rituals. Requires not empty.
+
+    ```groovy:no-line-numbers
+    name(String)
+    name(ResourceLocation)
+    ```
+
+- `int`. Sets the minimum book tier that can execute this recipe. Requires greater than or equal to 0 and less than or equal to 4. (Default `0`).
+
+    ```groovy:no-line-numbers
+    bookTier(int)
+    bookTier(String)
+    ```
+
+- `int`. Sets the particle ID that is emitted from pedestals while this recipe is being executed (see also: EnumRitualParticle). Requires greater than or equal to 0 and less than 8. (Default `3`).
+
+    ```groovy:no-line-numbers
+    particle(int)
+    ```
+
+- `int`. Sets the dimension that this ritual can be performed in. (Default `any dimension`).
+
+    ```groovy:no-line-numbers
+    dimension(int)
+    ```
+
+- `boolean`. Sets whether the ritual requires a sacrifice. (Default `false`).
+
+    ```groovy:no-line-numbers
+    sacrifice(boolean)
+    requiresSacrifice()
+    ```
+
+- First validates the builder, returning `null` and outputting errors to the log file if the validation failed, then registers the builder and returns the registered object. (returns `null` or `com.shinoow.abyssalcraft.api.ritual.NecronomiconInfusionRitual`).
+
+    ```groovy:no-line-numbers
+    register()
+    ```
+
+::::::::: details Example {open id="example"}
+```groovy:no-line-numbers
+mods.abyssaltweaker.ritual.recipeBuilder()
+    .name('starInfusion')
+    .input(item('minecraft:clay'), item('minecraft:diamond'), ore('ingotGold'), ore('ingotIron'))
+    .output(item('minecraft:nether_star'))
+    .pe(500)
+    .requiresSacrifice()
+    .bookTier(3)
+    .dimension(50)
+    .register()
+```
+
+:::::::::
+
+::::::::::
+
+## Removing Recipes
+
+- Removes the ritual by its center item:
+
+    ```groovy:no-line-numbers
+    mods.abyssaltweaker.ritual.removeByCenter(IIngredient)
+    ```
+
+- Removes the ritual by its name:
+
+    ```groovy:no-line-numbers
+    mods.abyssaltweaker.ritual.removeByName(String)
+    ```
+
+- Removes all recipes that match the given output:
+
+    ```groovy:no-line-numbers
+    mods.abyssaltweaker.ritual.removeByOutput(IIngredient)
+    ```
+
+- Removes all registered recipes:
+
+    ```groovy:no-line-numbers
+    mods.abyssaltweaker.ritual.removeAll()
+    ```
+
+:::::::::: details Example {open id="example"}
+```groovy:no-line-numbers
+mods.abyssaltweaker.ritual.removeByCenter(item('abyssalcraft:lifecrystal'))
+mods.abyssaltweaker.ritual.removeByName('dreadInfusedGatewayKey')
+mods.abyssaltweaker.ritual.removeByOutput(item('abyssalcraft:oc'))
+mods.abyssaltweaker.ritual.removeAll()
+```
+
+::::::::::
+
+## Getting the value of recipes
+
+- Iterates through every entry in the registry, with the ability to call remove on any element to remove it:
+
+    ```groovy:no-line-numbers
+    mods.abyssaltweaker.ritual.streamRecipes()
+    ```

--- a/docs/groovy-script/mods/abyssaltweaker/transmutation.md
+++ b/docs/groovy-script/mods/abyssaltweaker/transmutation.md
@@ -1,0 +1,109 @@
+---
+title: "Transmutation"
+titleTemplate: "Abyssal Tweaker | CleanroomMC"
+description: "Turns an input ItemStack into an output ItemStack."
+source_code_link: "https://github.com/TeamDimensional/AbyssalTweaker/blob/master/src/main/java/com/teamdimensional/abyssaltweaker/compat/groovyscript/RegistryTransmutation.java"
+---
+
+# Transmutation (Abyssal Tweaker)
+
+## Description
+
+Turns an input ItemStack into an output ItemStack.
+
+## Identifier
+
+Refer to this via any of the following:
+
+```groovy:no-line-numbers {1}
+mods.abyssaltweaker.transmutation/* Used as page default */ // [!code focus]
+mods.abyssaltweaker.Transmutation
+```
+
+
+## Adding Recipes
+
+### Recipe Builder
+
+Just like other recipe types, the Transmutation also uses a recipe builder.
+
+Don't know what a builder is? Check [the builder info page](../../getting_started/builder.md) out.
+
+:::::::::: details mods.abyssaltweaker.transmutation.recipeBuilder() {open id="abstract"}
+- `IngredientList<IIngredient>`. Sets the item inputs of the recipe. Requires exactly 1.
+
+    ```groovy:no-line-numbers
+    input(IIngredient)
+    input(IIngredient...)
+    input(Collection<IIngredient>)
+    ```
+
+- `ItemStackList`. Sets the item outputs of the recipe. Requires exactly 1.
+
+    ```groovy:no-line-numbers
+    output(ItemStack)
+    output(ItemStack...)
+    output(Collection<ItemStack>)
+    ```
+
+- `float`. Sets the XP amount output that is given out when the recipe is executed. Requires greater than or equal to 0. (Default `0.0f`).
+
+    ```groovy:no-line-numbers
+    xp(float)
+    ```
+
+- First validates the builder, returning `null` and outputting errors to the log file if the validation failed, then registers the builder and returns the registered object. (returns `null` or `com.shinoow.abyssalcraft.api.recipe.Transmutation`).
+
+    ```groovy:no-line-numbers
+    register()
+    ```
+
+::::::::: details Example {open id="example"}
+```groovy:no-line-numbers
+mods.abyssaltweaker.transmutation.recipeBuilder()
+    .input(item('minecraft:clay'))
+    .output(item('minecraft:diamond'))
+    .xp(0.5)
+    .register()
+```
+
+:::::::::
+
+::::::::::
+
+## Removing Recipes
+
+- Removes all recipes that match the given input:
+
+    ```groovy:no-line-numbers
+    mods.abyssaltweaker.transmutation.removeByInput(IIngredient)
+    ```
+
+- Removes all recipes that match the given output:
+
+    ```groovy:no-line-numbers
+    mods.abyssaltweaker.transmutation.removeByOutput(IIngredient)
+    ```
+
+- Removes all registered recipes:
+
+    ```groovy:no-line-numbers
+    mods.abyssaltweaker.transmutation.removeAll()
+    ```
+
+:::::::::: details Example {open id="example"}
+```groovy:no-line-numbers
+mods.abyssaltweaker.transmutation.removeByInput(item('minecraft:diamond'))
+mods.abyssaltweaker.transmutation.removeByOutput(item('minecraft:flint'))
+mods.abyssaltweaker.transmutation.removeAll()
+```
+
+::::::::::
+
+## Getting the value of recipes
+
+- Iterates through every entry in the registry, with the ability to call remove on any element to remove it:
+
+    ```groovy:no-line-numbers
+    mods.abyssaltweaker.transmutation.streamRecipes()
+    ```

--- a/docs/groovy-script/mods/index.md
+++ b/docs/groovy-script/mods/index.md
@@ -5,6 +5,7 @@ search:
 
 # Mods
 
+* [Abyssalcraft 2 (with Abyssal Tweaker)](./abyssaltweaker/)
 * [Actually Additions](./actuallyadditions/)
 * [Advanced Mortars](./advancedmortars/)
 * [Advanced Rocketry](./advancedrocketry/)


### PR DESCRIPTION
My mod [Abyssal Tweaker](https://www.curseforge.com/minecraft/mc-mods/abyssal-tweaker) (currently 404's because I have never published it, I'll undraft it when it releases) allows adding recipes to Abyssalcraft 2 through Groovyscript. This PR adds the documentation for the mod's GS integration to the GS wiki. All wiki files were automatically generated, proofread and no issues were found.