### PR TITLE
add IntelliJ IDEA to editors

### DIFF
--- a/docs/groovy-script/getting_started/editors.md
+++ b/docs/groovy-script/getting_started/editors.md
@@ -31,6 +31,8 @@ This extension will work with any fork of VS Code, but will presume you are usin
 GroovyScript has created an extension, called [`GroovyScript`](https://marketplace.visualstudio.com/items?itemName=CleanroomMC.groovyscript&ssr=false#overview), distributed by `CleanroomMC`.
 This extension adds syntax validation, auto-completion for all installed mods, and hover information.
 
+The source code can be viewed [here](https://github.com/CleanroomMC/GroovyScript/tree/master/editors/vscode).
+
 
 ### Installation
 
@@ -50,6 +52,8 @@ The plugin will work with either Community Edition or Ultimate.
 [`Integer Limit`](https://github.com/IntegerLimit) has created a plugin, called [`GroovyScript`](https://plugins.jetbrains.com/plugin/25915-groovyscript),
 distributed by `IntegerLimit`.
 This plugin adds syntax validation, auto-completion for all installed mods, and hover information.
+
+The source code can be viewed [here](https://github.com/IntegerLimit/GroovyScriptPlugin).
 
 
 ### Installation

--- a/docs/groovy-script/getting_started/editors.md
+++ b/docs/groovy-script/getting_started/editors.md
@@ -42,6 +42,26 @@ This extension adds syntax validation, auto-completion for all installed mods, a
 6. Done
 
 
+## IntelliJ IDEA
+
+[IntelliJ IDEA](https://www.jetbrains.com/idea/) is an Integrated Development Environment created and distributed by JetBrains.
+The plugin will work with either Community Edition or Ultimate.
+
+[`Integer Limit`](https://github.com/IntegerLimit) has created a plugin, called [`GroovyScript`](https://plugins.jetbrains.com/plugin/25915-groovyscript),
+distributed by `IntegerLimit`.
+This plugin adds syntax validation, auto-completion for all installed mods, and hover information.
+
+
+### Installation
+
+1. Open IntelliJ IDEA and install the [LSP4IJ](https://plugins.jetbrains.com/plugin/23257-lsp4ij) plugin and the [`GroovyScript`](https://plugins.jetbrains.com/plugin/25915-groovyscript) plugin
+2. Open the instance folder (typically `minecraft`) or the `groovy` folder of a modpack in IntelliJ IDEA.
+3. [Start the Language Server](#start-the-language-server) via the instructions above
+4. The port in the `groovyscript.cfg` config file must match the port setting in the IntelliJ IDEA plugin.
+5. The server will now automatically connect.
+6. Done
+
+
 ## Emacs
 
 [Emacs](https://www.gnu.org/software/emacs/) is a group of open source editors, with the largest edition being distributed by GNU.

--- a/docs/groovy-script/getting_started/editors.md
+++ b/docs/groovy-script/getting_started/editors.md
@@ -28,8 +28,16 @@ By default, the language server is started with a port of `25564`. This is confi
 [VS Code](https://code.visualstudio.com/) is an editor built on open source software and distributed by Microsoft.
 This extension will work with any fork of VS Code, but for the purposes of this page the wording presumes you are using VS Code.
 
-GroovyScript has created an extension, called [`GroovyScript`](https://marketplace.visualstudio.com/items?itemName=CleanroomMC.groovyscript&ssr=false#overview), distributed by `CleanroomMC`.
-This extension adds syntax validation, auto-completion for all installed mods, and hover information.
+The extension is released under the name [`GroovyScript`](https://marketplace.visualstudio.com/items?itemName=CleanroomMC.groovyscript&ssr=false#overview)
+and distributed by the publisher [`CleanroomMC`](https://marketplace.visualstudio.com/publishers/CleanroomMC).
+It adds syntax validation, auto-completion for all installed mods, and hover information.
+For more information, check the readme of the project.
+
+::: info Contributors {id="tip"}
+
+This extension was created by [`zznty`](https://github.com/zznty) and [`brachy`](https://github.com/brachy84).
+
+:::
 
 The source code can be viewed [here](https://github.com/CleanroomMC/GroovyScript/tree/master/editors/vscode).
 
@@ -49,20 +57,27 @@ The source code can be viewed [here](https://github.com/CleanroomMC/GroovyScript
 [IntelliJ IDEA](https://www.jetbrains.com/idea/) is an Integrated Development Environment created and distributed by JetBrains.
 The plugin will work with either Community Edition or Ultimate.
 
-[`Integer Limit`](https://github.com/IntegerLimit) has created a plugin, called [`GroovyScript`](https://plugins.jetbrains.com/plugin/25915-groovyscript),
-distributed by `IntegerLimit`.
-This plugin adds syntax validation, auto-completion for all installed mods, and hover information.
+The plugin is released under the name [`GroovyScript`](https://plugins.jetbrains.com/plugin/25915-groovyscript)
+and distributed by the vendor [`IntegerLimit`](https://plugins.jetbrains.com/vendor/integerlimit).
+It adds syntax validation, auto-completion for all installed mods, and hover information.
+For more information, check the readme of the project.
+
+::: info Contributors {id="tip"}
+
+This plugin was created by [`Integer Limit`](https://github.com/IntegerLimit).
+
+:::
 
 The source code can be viewed [here](https://github.com/IntegerLimit/GroovyScriptPlugin).
 
 
 ### Installation
 
-1. Open IntelliJ IDEA and install the [LSP4IJ](https://plugins.jetbrains.com/plugin/23257-lsp4ij) plugin and the [`GroovyScript`](https://plugins.jetbrains.com/plugin/25915-groovyscript) plugin
+1. Open IntelliJ IDEA and install the [`GroovyScript`](https://plugins.jetbrains.com/plugin/25915-groovyscript) plugin
 2. Open the instance folder (typically `minecraft`) or the `groovy` folder of a modpack in IntelliJ IDEA.
 3. [Start the Language Server](#start-the-language-server) via the instructions above
 4. The port in the `groovyscript.cfg` config file must match the port setting in the IntelliJ IDEA plugin.
-5. The server will now automatically connect.
+5. The server will try to connect automatically. If it cannot connect, restart it by accessing the Language Servers Tab and then right clicking on the GroovyScript LSP entry.
 6. Done
 
 

--- a/docs/groovy-script/getting_started/editors.md
+++ b/docs/groovy-script/getting_started/editors.md
@@ -26,7 +26,7 @@ By default, the language server is started with a port of `25564`. This is confi
 ## Visual Studio Code
 
 [VS Code](https://code.visualstudio.com/) is an editor built on open source software and distributed by Microsoft.
-This extension will work with any fork of VS Code, but will presume you are using VS Code.
+This extension will work with any fork of VS Code, but for the purposes of this page the wording presumes you are using VS Code.
 
 GroovyScript has created an extension, called [`GroovyScript`](https://marketplace.visualstudio.com/items?itemName=CleanroomMC.groovyscript&ssr=false#overview), distributed by `CleanroomMC`.
 This extension adds syntax validation, auto-completion for all installed mods, and hover information.


### PR DESCRIPTION
changes in this PR:
- a plugin was created for IntelliJ IDEA by @IntegerLimit https://plugins.jetbrains.com/plugin/25915-groovyscript. adds this to the wiki in the same format as the other editors.
- add links to the source code for both the existing VS Code and new IntelliJ IDEA entries.
- fix the wording for using VS Code forks being weird.