### PR TITLE
Add render docs page under wiki/mod-dev/render

### DIFF
--- a/docs/.vitepress/config/en.ts
+++ b/docs/.vitepress/config/en.ts
@@ -108,6 +108,10 @@ function wikiSidebar(): DefaultTheme.SidebarItem[] {
               text: "Colouring Blocks and Items",
               link: "colouring-blocks-and-items",
             },
+            {
+                text: "Render Documentation",
+                link: "render-documentation",
+            }
           ],
         },
         { text: "Behaviour", link: "behaviour" },

--- a/docs/wiki/forge-mod-development/render/render-documentation.md
+++ b/docs/wiki/forge-mod-development/render/render-documentation.md
@@ -1,0 +1,18 @@
+---
+title: Render Documentation
+---
+
+# Rendering Documentation
+
+This document provides resources and information related to rendering.
+
+## Mc 122 Render Book
+
+- **[GitHub Repository: Mc122RenderBook](https://github.com/tttsaurus/Mc122RenderBook)**  
+  - This repository is a comprehensive collection of rendering examples and experiments designed for Minecraft 1.12.2.  
+  - It serves as a resource for beginners to understand rendering, particularly OpenGL, within the Minecraft environment.
+
+### Key Features
+
+- **Examples:** Primarily consists of examples, allowing you to easily copy and learn.
+- **Experimentation:** A variety of experiments to explore rendering concepts.


### PR DESCRIPTION
- Added a new page `wiki/forge-mod-development/render/render-documentation`
- Put a link of my repo [Mc122RenderBook](https://github.com/tttsaurus/Mc122RenderBook) under that page