### PR TITLE
Update editors.md to add examples to use the LSP with coc.nvim

### DIFF
--- a/docs/groovy-script/getting_started/editors.md
+++ b/docs/groovy-script/getting_started/editors.md
@@ -151,7 +151,7 @@ This language support will work with any variation of Emacs, but will presume yo
 
 ## Vim/Neovim with coc.nvim
 
-[Vim](https://www.vim.org)/[Neovim](https://neovim.io/) are editors based off the Vi unix editor.
+[Vim](https://www.vim.org)/[Neovim](https://neovim.io/) are editors based off the Vi Unix editor.
 
 ### Installation
 
@@ -168,7 +168,10 @@ This language support will work with any variation of Emacs, but will presume yo
       "host": "127.0.0.1",
       "port": 25564,
       "filetypes": [
-        "groovy"
+        "groovy",
+        "gvy",
+        "gy",
+        "gsh"
       ]
     }
     ...

--- a/docs/groovy-script/getting_started/editors.md
+++ b/docs/groovy-script/getting_started/editors.md
@@ -148,3 +148,36 @@ This language support will work with any variation of Emacs, but will presume yo
 3. [Start the Language Server](#start-the-language-server) via the instructions above
 4. The port in the `groovyscript.cfg` config file must match the port setting.
 5. Done
+
+## Vim/Neovim with coc.nvim
+
+[Vim](https://www.vim.org)/[Neovim](https://neovim.io/) are editors based off the Vi unix editor.
+
+### Installation
+
+1. Open Vim/Neovim and install [coc.nvim](https://github.com/neoclide/coc.nvim/), and follow further installation instructions for lsp-mode.
+2. Run :CocConfig to open the configuration file, and edit the languageserver field as such:
+:::: details GroovyScript LSP {id="vim-example"}
+::: code-group
+```json [~/.vim/coc-settings.json]
+{
+  ...
+  "languageserver": {
+    ...
+    "groovyscript": {
+      "host": "127.0.0.1",
+      "port": 25564,
+      "filetypes": [
+        "groovy"
+      ]
+    }
+    ...
+  }
+  ...
+}
+```
+:::
+::::
+3. [Start the Language Server](#start-the-language-server) via the instructions above
+4. The port in the `groovyscript.cfg` config file must match the port setting.
+5. Done


### PR DESCRIPTION
Added examples to use the GroovyScript LSP on Vim and Neovim using the coc.nvim plugin.